### PR TITLE
improve 404 pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,9 @@ theme:
   favicon: assets/favicon.png
   features:
     - navigation.tabs
+  custom_dir: overrides
+  static_templates:
+    - 404.html
 extra_css:
   - styles/theme.css
 extra:

--- a/overrides/404.html
+++ b/overrides/404.html
@@ -1,0 +1,17 @@
+{% extends "main.html" %}
+
+<!-- Content -->
+{% block content %}
+<h1>Not found</h1>
+<p>
+  It looks like we don't have a Wiki page for this course yet, or you may have
+  mistyped this URL.
+</p>
+<p>
+  To request a Wiki page for this course, please
+  <a href="https://github.com/hkn-alpha/website/issues">open a GitHub issue</a>
+  and we'll get to it as soon as we can. Or, if you want to write the Wiki page
+  for this course, follow the contributing instructions in our
+  <a href="https://github.com/hkn-alpha/wiki">GitHub repository</a>. Thank you!
+</p>
+{% endblock %}


### PR DESCRIPTION
![image](https://github.com/hkn-alpha/wiki/assets/16417432/8cfba17c-9341-4ffd-86cc-faf641fc8360)

Improves the 404 page text to be something useful (previously it was just the default Not Found heading)