### PR TITLE
Changes for math prof exam pages

### DIFF
--- a/docs/Proficiency Exams/MATH231.md
+++ b/docs/Proficiency Exams/MATH231.md
@@ -24,7 +24,7 @@ It's not an easy proficiency exam, and does require some preparation. This test 
 
 ## Exam Format
 
-The exam consists of a number of msotly multiple-choice questions (typically up to 5 options to pick from) and a handful of open-ended questions. The exam duration is 3 hours, but the exam is designed to take 1.5-2 hours on average.
+As of 2024, the math proficiency exams have been moved to the CBTF. The exam consists of all multiple-choice questions (typically up to 5 options to pick from). The exam duration is 3 hours, but the exam is designed to take 1.5-2 hours on average.
 
 ## How to Prepare
 

--- a/docs/Proficiency Exams/MATH285.md
+++ b/docs/Proficiency Exams/MATH285.md
@@ -1,6 +1,6 @@
 # MATH285
 
-[MATH285 (Intro Differential Equations)](../Course%20Wiki/MATH%20Course%20Offerings/MATH231.md) is 3-credit hour course required for all ECE students and many other engineering disciplines under Grainger.
+[MATH285 (Intro Differential Equations)](../Course%20Wiki/MATH%20Course%20Offerings/MATH285.md) is 3-credit hour course required for all ECE students and many other engineering disciplines under Grainger.
 
 ## Who Should Take the Exam
 

--- a/docs/Proficiency Exams/MATH285.md
+++ b/docs/Proficiency Exams/MATH285.md
@@ -1,0 +1,36 @@
+# MATH285
+
+[MATH285 (Intro Differential Equations)](../Course%20Wiki/MATH%20Course%20Offerings/MATH231.md) is 3-credit hour course required for all ECE students and many other engineering disciplines under Grainger.
+
+## Who Should Take the Exam
+
+For students who want to take [ECE210](../Course%20Wiki/ECE%20Course%20Offerings/ECE210.md) early, it may be beneficial to take the MATH285 exam. However, ECE210 only have a corequisite requirement with MATH285, meaning MATH285 can be taken at the same time as ECE210. Therefore, it only makes sense to take the exam if students are trying to graduate early, don't have the space in their schedules to take MATH285, and feel very confident with the material covered in the course.
+
+It's not an easy proficiency exam, and does require some preparation. This test is mainly for students who have covered a majority the MATH285 syllabus beforehand, but did not get credit transferred for it when enrolling into UIUC. However, like all proficiency exams, there is no penalty for failing the MATH285 proficiency exam, so if you're on the fence, take the exam.
+
+## Content Covered
+
+- First order ODEs
+- Second-order ODE's
+- Damped/Undamped/Forced/Unforced Harmonic Oscillators
+- Higher order ODEs
+- Boundary Value Problems
+- Fourier Series / Periodically Forced Oscillators
+- Heat Equation
+- Wave Equation
+- Laplace's Equation
+- Sturm-Liouville Theory and Eigenfunction Series
+
+## Exam Format
+
+As of 2024, the math proficiency exams have been moved to the CBTF. The exam consists of all multiple-choice questions (typically up to 5 options to pick from). The exam duration is 3 hours, but the exam is designed to take 1.5-2 hours on average.
+
+## How to Prepare
+
+[The official syllabus list](https://math.illinois.edu/resources/syllabus-math-285) has all the information you need regarding the content covered for the exam. Here you can details on the official textbook used for the course. The textbook contains many practice questions that are similar in difficulty to the proficiency exam, so it is highly recommended to acquire an online or physical copy of the textbook if you can. For additional resources, check out this TA's [course page](https://daesungk.github.io/teaching/math285-f20-uiuc/). The page includes lecture notes as well as previous exams with answers keys. The resources on this page are the best way to study for the exam.
+
+## Life After
+
+If you pass the MATH285 proficiency exam, you have a solid understanding in solving, classifying, and approximating various differential equation types. To make the most the material in MATH285, take ECE210 as soon as possible. Doing so will speed up your ECE journey, allowing yourself more semesters to take interesting ECE electives or even graduate early. The material covered in MATH285 is also relevant in many EE-centric courses such as ECE310 and ECE350.
+
+If you don't pass the MATH285 proficiency exam, don't be disheartened: the exam tests on more advanced topics, and there is a wide range of content covered. Your efforts to study MATH285 material before the semester will still pay off, and the course will be easier for you than students who are learning those concepts for the first time. It will also give you an edge when it comes to the aforementioned postrequisite courses.


### PR DESCRIPTION
Adds in a page for the proficiency exam MATH 285 and fixes a typo on the MATH 231 page. 