### PR TITLE
Update ECE110.md

### DIFF
--- a/docs/Course Wiki/ECE Course Offerings/ECE110.md
+++ b/docs/Course Wiki/ECE Course Offerings/ECE110.md
@@ -23,36 +23,33 @@ There are no prerequisites for this course.
 
 ## When to Take it
 
-This course should be taken in either semester freshman year so that ECE 210 can be taken as a sophomore. In general, ECE should be taken wherever it fits in best with other freshamn courses, as it doesn't have much overlap with any other courses at the 100 or 200 levels. However, for someone trying to get into ECE210 as soon as possible to get to upper level EE classes, it should be taken during the first semester as a freshman. For a capable freshman, ECE110 and ECE120 can be taken simultaneously, which is probably the best course of action for a student who has already covered several early required courses and/or is trying to accelerate their path to the upper level ECE courses.
+This course should be taken in either semester freshman year so that ECE210 can be taken as a sophomore. In general, ECE110 should be taken wherever it fits in best with other freshamn courses, as it doesn't have much overlap with any other courses at the 100 or 200 levels. However, for someone trying to get into ECE210 as soon as possible to get to upper level EE classes, it should be taken during the first semester as a freshman. For a capable freshman, ECE110 and ECE120 can be taken simultaneously, which is probably the best course of action for a student who has already covered several early required courses and/or is trying to accelerate their path to the upper level ECE courses.
 
 ## Course Structure
 
 This course's workload is relatively light compared to other courses, but can be tough on an incoming student getting used to university workloads. Weekly homeworks are assigned on both Prairielearn and Gradescope. The Prairielearn sections are multiple choice or short answer, with answers being graded only on correctness. The Gradescope homework is comprised of variations of two of that week's Prairielearn questions, which need to have work written out. Answers for these are graded on work quality as well as correctness.
 
-In addition to the homework, there is a lab section that comprises 30% of the entire class grade. Lab takes place once a week as a 3 hour section. Lab involves various circuit building projects with a four person group. Lab assignments consist of pre-lab and post-lab every week, working mostly in lab with the lab kit provided by the department. Attendance for lab is mandatory, and failure to get a passing grade in the lab category results in failure of the class.
+In addition to the homework, there is a lab section that comprises 30% of the entire class grade. Lab takes place once a week as a 3 hour section and involves various circuit building projects with a four person group. Additionally, a short pre-lab assignment must be completed before each lab, and a lab report must be written after each lab. Attendance for lab is mandatory, and failure to get a passing grade in the lab category results in failure of the class.
 
-This course has 3 quizzes, which can be considered as midterms, as well as a final exam. The worst quiz score can be replaced by the score on the final exam if it is higher. Each of these are Prarietest exams, which are similiar to the Prairelearn homework, just taking place in a condensed time limit and a controlled environment. Quizzes are 50 minutes long in the CBTF, with exam slots being selectable over a given exam period. In addition, quiz retakes are allowed, where students can gain back a percentage of the difference between their original score and 100%. These are given to students who finish the Section Review. The final exam is similar, with a 3 hour time limit for 30 questions. No retake is allowed for the final exam.
+This course has 3 quizzes, which can be considered as midterms, as well as a final exam. Each of these are Prarietest exams, which are similiar to the Prairelearn homework, just taking place in a condensed time limit and a controlled environment. Quizzes are 50 minutes long in the CBTF, with exam slots being selectable over a given exam period. In addition, quiz retakes are allowed, where students can gain back a percentage of the difference between their original score and 100%. Retakes are available to students who score at least 75% on a quiz's section review, which is an optional Prairielearn assignment. The final exam is also at the CBTF and is similar to the quizzes, except the time limit is three hours instead of one hour.
 
 This course is graded on an absolute scale, meaning students are graded based on a performance standard, not their performance relative to other students, so doing well on the quizzes and exams is vital to doing well in the class. Extra credit is available, but only for the lab grade. Getting full extra credit is enough to make up for one missed lab. Grading distribution is as follows:
 
 - Quizzes (10% each, 30% total)
 - Final Exam (25%)
-- Homework (15%)
+- Homework (14%)
+- Lecture Attendance (1%)
 - Laboratory (30%)
 
 ## Instructors
 
-The instructors in this course vary each semester based on availability and student demand. The current course director is Professor Jonathon Schuh. This semester (Fall 2025), the instructor list includes Professors Jonathon Schuh, Hyungsoo Choi, Yang Zhao, and Christopher Schmitz. Professors Wandke and Shao have also taught the course.
+The instructors in this course vary each semester based on availability and student demand. The current course director is Professor Schuh. In the spring 2026 semester, the instructor list includes Professors Schuh, Schmitz, Yu, and Shao.
 
 ## Course Tips
 
-The most difficult part about the class is the 3 hour lab section and it's not particularly close. In the first place, planning it in your scheduling is one of the most annoying things you do as a freshman because 3 hours blocks out a lot of potential class time and the lab can be frustrating whether you're good at it or not. Taking some time beforehand to prep for lab and starting work early goes a long way for making your life easier. Make sure to take advantage of the TAs in your lab section by asking plenty of questions to ensure you fully understand the material, as labs typically build upon concepts from previous labs. In addition to that, attending weekly lab office hours to sharpen your understandings and/or do extra credit assignments would be a great way to be good at lab.
+The most difficult part about the class is the 3 hour lab section and it's not particularly close. In the first place, planning it in your scheduling is one of the most annoying things you do as a freshman because 3 hours blocks out a lot of potential class time and the lab can be frustrating whether you're good at it or not. Taking some time beforehand to prep for lab and starting work early goes a long way for making your life easier. Make sure to take advantage of the TAs in your lab section by asking plenty of questions to ensure you fully understand the material, as labs typically build upon concepts from previous labs. Having a clear understanding of how and why the circuits behave as they do will make future labs, including the lab final, easier to complete. Additionally, try to maintain clear and open communication with your lab groupmates. During the lab, you will be assigned projects that will likely require your group to meet on your own time, outside of the scheduled lab period, so keeping constant communication with your lab partners will make scheduling and collaborating easier. This becomes incredibly necessary during the lab final, where each group member will be responsible for creating a different portion of the total project, with the group needing to combine these parts together at the end. Besides understanding the concepts behind the lab material, establishing effective group habits is the biggest key to success in your lab section.
 
-Having a clear understanding of how and why the circuits behave as they do will make future labs, including the lab final, easier to complete. Additionally, try to maintain clear and open communication with your lab groupmates. During the lab, you will be assigned projects that will likely require your group to meet on your own time, outside of the scheduled lab period, so keeping constant communication with your lab partners will make scheduling and collaborating easier. This becomes incredibly necessary during the lab final, where each group member will be responsible for creating a different portion of the total project, with the group needing to combine these parts together at the end. Besides understanding the concepts behind the lab material, establishing effective group habits is the biggest key to success in your lab section.
-
-Practice exams are given out for each quiz and the final, but that's not your only resource. It should go without saying, but because Prairielearn and Prairietest are basically the same, questions can also come off the homework and section review. Questions are always going to be something similar to a question you've already seen. Do not make assumptions you will get the exact questions on the exams. Instead, understand the materials and how to solve a question. Solving each Prairielearn question like how you do it on Gradescope is a great way to practice. 
-
-When you take exams, stay calm, hydrated, and have confidence in yourself. Take a lot of draft papers and do decently detailed work on it (which should help you get the correct answer on first try or make it easier to figure out the issue). It is also a good practice to solve problem, save it using the "Save only" button, and come back to check your work after before submitting.
+Practice exams are given out for each quiz and the final, but that's not your only resource. It should go without saying, but because Prairielearn and Prairietest are basically the same, questions can also come off the homework and section review. Questions are always going to be something similar to a question you've already seen; there's almost never any entirely new questions on any exam.
 
 ## Life After
 
@@ -64,9 +61,9 @@ While most of the "Life After ECE110" content comes after ECE210, there is one i
 
 ## Infamous Topics
 
-- Going over the Node Method and Thevenin and Norton can be tricky because they are very intuitive, but they have to be understood well as they are covered well on exams and extremely important for future classes.
+- Going over the node voltage method and Thevenin and Norton equivalent circuits can be tricky because they are not very intuitive, but they have to be understood well as they are covered well on exams and extremely important for future classes.
 
-- Otherwise, the big source of trouble in this class, aside from the exams, is the lab final, a circuit project students are typically given 2-3 weeks to complete. Lab office hours tend to be busiest around this time and the project itself can be a big hit or miss depending on how well lab content is truly understood.
+- Otherwise, the big source of trouble in this class, aside from the exams, is the lab final, a circuit project students are typically given 3-4 weeks to complete. Lab office hours tend to be busiest around this time and the project itself can be a big hit or miss depending on how well lab content is truly understood.
 
 ## Resources
 


### PR DESCRIPTION
When to Take it:
	ECE 210 -> ECE210, to be consistent with how it is formatted in the rest of the paragraph
	ECE -> ECE110, because it is a typo

Course Structure:
	"Lab takes place once a week as a 3 hour section. Lab involves various circuit building projects with a four person group. Lab assignments consist of pre-lab and post-lab every week, working mostly in lab with the lab kit provided by the department." -> "Lab takes place once a week as a 3 hour section and involves various circuit building projects with a four person group. Additionally, a short pre-lab assignment must be completed before each lab, and a lab report must be written after each lab.", improve sentence flow, and elaborate on pre-lab and post-lab assignments
	Remove "The worst quiz score can be replaced by the score on the final exam if it is higher" since it does not appear on the course syllabus, and is therefore likely outdated
	"These are given to students who complete an individual goal, which has most recently been a 75% lecture attendance record." -> "Retakes are available to students who score at least 75% on a quiz's section review, which is an optional Prairielearn assignment.", replace outdated information
	"The final exam is similar, with a 3 hour time limit instead of the one." -> "The final exam is also at the CBTF and is similar to the quizzes, except the time limit is three hours instead of one hour.", improve phrasing
	" - Homework (15%)" -> " - Homework (14%) \n - Lecture Attendance (1%)", updating outdated information

Instructors:
	"The current course director is Professor Schmitz. This semester (Fall 2023), the instructor list includes Professors Matthew Gilbert, Jonathon Schuh, Hyungsoo Choi, and Kyekyoon Kim. Professors Wandke, Shao, and Schmitz have also recently taught the course." -> "The current course director is Professor Schuh. In the spring 2026 semester, the instructor list includes Professors Schuh, Schmitz, Yu, and Shao.", update info

Infamous Topics:
	"Going over the Node Method and Thevenin and Norton can be tricky because they are very intuitive," -> "Going over the node voltage method and Thevenin and Norton equivalent circuits can be tricky because they are not very intuitive,", improve clarity and correct the meaning of the sentence