### PR TITLE
Update CS173 12-6-25.md

### DIFF
--- a/docs/Course Wiki/CS Course Offerings/CS173.md
+++ b/docs/Course Wiki/CS Course Offerings/CS173.md
@@ -4,71 +4,68 @@ tags:
 ---
 # CS173
 
-CS173 (Discrete Structures) is a 3-credit hour course that is specifically required for CS majors and CEs and qualifies as a technical elective for EEs. It is offered in both the fall and spring. [MATH213](../MATH%20Course%20Offerings/MATH213.md) may substitute this course for ECE majors, and cannot for CS majors.
+CS173 (Discrete Structures) is a 3-credit-hour course that is specifically required for CS majors and CEs and qualifies as a non-ECE technical elective for EEs. It is offered in both the fall and spring. [MATH213](../MATH%20Course%20Offerings/MATH213.md) may substitute this course for ECE majors, but not for CS majors.
 
 ## Content Covered
 
-The topics covered in CS 173 will introduce number theory concepts, mathematical proofs, especially inductive proofs, set theory, graph theory, recursive relations, trees, counting, common algorithms, and big O analysis. 
+The topics covered in CS 173 will introduce number theory concepts, mathematical proofs, especially inductive proofs, set theory, graph theory, recursive relations, trees, counting, common algorithms, and big-O analysis. 
 
 ### Topics
 
 - Math Concepts and Basic Boolean Logic
 - Proofs and Number Theory
-- Modular Arithmatic and Sets
-- Relations
+- Modular Arithmetic and Sets
+- Collections of Sets
 - Functions
 - Graphs and 2-way Bounding
-- Induction
+- Proof by Induction
 - Recursive Definition
 - Trees and Grammars
 - Big-O and Algorithms
-- NP Time
-- Collections of Sets
-- Contradiction State Diagrams
-- State Diagrams Countability
+- Proof by Contradiction
+- Countability
+- State Diagrams
 
 ## Prerequisites
 
 - [CS124](./CS124.md) OR [ECE220](../ECE%20Course%20Offerings/ECE220.md)
 - [MATH220](../MATH%20Course%20Offerings/MATH220.md) OR [MATH221](../MATH%20Course%20Offerings/MATH221.md)
 
-CS 173's few prerequisites are of limited importance to being able to succeed in the course. Coding experience is mainly helpful for analyzing Big-O for several algorithms but also helps in the specific mindset it promotes. Having the prerequisites done is still recommended, especially since the requirement for ECE students to take ECE 220 before this course has been enforced recently.
+CS 173's few prerequisites are of limited importance to being able to succeed in the course. Coding experience is mainly helpful for analysing Big-O for several algorithms, but also helps in the specific mindset it promotes. Having the prerequisites done is still recommended, especially since the requirement for ECE students to take ECE 220 before this course has been enforced recently.
 
 ## When to Take it
 
 Due to this class being a hard prerequisite for [CS 225](./CS225.md), we now recommend taking [MATH213](../MATH%20Course%20Offerings/MATH213.md) instead of CS173 concurrently with ECE 220 instead.
 
-Discrete Structures officially a prerequisite for CS 225, which is the gateway to most, if not all CS courses.  As such, take Discrete Structures as early as possible, especially for Computer Engineering majors.  Most higher-level CS courses will definitely cover discrete math concepts so the topics introduced in CS 173 will be reviewed again and again.  Furthermore, a lot of the computer engineering concepts are also introduced in this class and so it will complement a lot of early computer engineering classes, like ECE 120 and ECE 220.  Though it is possible to do well even when taking discrete structures concurrently with a coding class, like ECE 220 or CS 125, it is highly recommended to take the coding class before taking CS 173.  Exposure to coding will greatly help the understanding of discrete math and taking them concurrently will most likely just be a bigger burden to try and grasp the concepts faster. 
+Discrete Structures is officially a prerequisite for CS 225, which is the gateway to most, if not all CS courses.  As such, take Discrete Structures as early as possible, especially for Computer Engineering majors.  Most higher-level CS courses will definitely cover discrete math concepts, so the topics introduced in CS 173 will be reviewed again and again.  Furthermore, a lot of the computer engineering concepts are also introduced in this class, so it will complement a lot of early computer engineering classes, like ECE 120 and ECE 220.  Though it is possible to do well even when taking discrete structures concurrently with a coding class, like ECE 220 or CS 125, it is highly recommended to take the coding class before taking CS 173.  Exposure to coding will greatly help the understanding of discrete math, and taking them concurrently will most likely just be a bigger burden to try and grasp the concepts faster. 
 
 ## Course Structure
 
 ### Lecture
 
-There are Tuesday lectures, where the professors go over the week's content and do some practice problems.
-CS173 has 2-5 asynchronous lecture videos per week which are posted on the course website.  Aside from this, lecture notes and sections to read are also posted, which go over the topics covered in the videos. Attendance is not required for them.
+There are Tuesday lectures, where the professors go over the week's content and do some practice problems. Attendance is not graded for them.
+Aside from this, lecture notes and sections to read are also posted.  The textbook for this course is very well-written, and it is highly recommended that you read it.
 
 ### Tutorial and Homework
 
-CS173 has tutorial sections similar to discussion sections of other classes. In tutorial, you work on extra problems with classmates, while CAs and TAs walk around to answer any questions you may have. After you have finished the tutorial problems, you get checked off by a CA/TA.  You can do multiple submissions on the tutorials.
+CS173 has tutorial sections similar to discussion sections of other classes. In tutorial, you work on extra problems with classmates, while CAs and TAs walk around to answer any questions you may have. After you have finished the tutorial problems, you get checked off by a CA/TA.  Tutorials are graded on completion, not correctness.
 
-The pretutorial checkpoints are due the day before tutorial as an autograded PrairieLearn homework.  They are simpler questions designed to make sure that you have completed the readings and watched the lecture videos online.
-
-The homework is due 4 days after tutorial.  These are also due on PrairieLearn and you can resubmit them as many times as you want.
+The homework is due on Mondays, the day before the material on the homework will be covered in lecture.  These are to make sure that you read the textbook before lecture.  Homework is autograded on PrarieLearn with unlimited attempts.
 
 ### Exams and Grading
 
-CS173 has 7 smaller Examlets and a final, and typically does not curve exam scores. Exam scores make up roughly 90% of a student's grade and the remainder comes from pretutorial checkpoints and homework.
-The examlets are 50 minutes in length, and the final is 2 hours in length.
-The 3 lowest checkpoint grades and 3 lowest homework grades are dropped when computing your final averages. You can submit these multiple times, so it should not be too difficult to ultimately get 100% on all of them.
+CS173 has 7 smaller Examlets every other week and a final at CBTF, and typically does not curve exam scores. Exam scores make up 90% of a student's grade, and the remainder comes from tutorials and homework.
+The examlets are 50 minutes in length, and the final is 2 hours in length.  The examlets typically have two free-response questions that are graded manually, while the rest of the questions are auto-graded.
+The 3 lowest tutorial grades and the lowest 3 homework grades are dropped when computing your final grades. You can submit homework multiple times, and tutorials are graded on completion, so it should not be too difficult to get 100% on all of them.
 
 
 ## Instructors
 
-Professor Margaret Fleck and Professor Benjamin Cosman usually teach CS 173; however, there may be some different professors in different semesters. The professors historically are great at carefully explaining confusing material during their office hours and to a limited degree lecture. They typically take extra care to ensure that all questions are answered and the material is learned during these office hours.
+Professor Margaret Fleck and Professor Benjamin Cosman usually teach CS 173; however, there may be some different professors in different semesters. In Fall 2025 and Spring 2026, Carl Evans and Dan Gonzalez taught CS 173. The professors historically are great at carefully explaining confusing material during their office hours, and to a limited degree lecture. They typically take extra care to ensure that all questions are answered and the material is learned during these office hours.
 
 ## Course Tips
 
-Discrete Structures can be a straightforward class but it is very easy to fall behind at the end of the semester. The homework can be difficult, so it is good to check answers with other students. The examlets usually consists of one large proof-like problem and other smaller problems. These often consist of similar problems shown on the older exams, so reviewing those before the examlets can be very helpful.
+Discrete Structures can be a straightforward class, but it is very easy to fall behind at the end of the semester. The examlets usually consist of one large proof-like problem and other smaller problems. These often consist of similar problems shown on the older exams, so reviewing those before the examlets can be very helpful.
 
 ## Life After
 


### PR DESCRIPTION
Updated content for Fall 2025. Removed content about lecture videos and pretutorial checkpoints as the class no longer has those. Fixed grammar. Updated instructors section to reflect current instructors.